### PR TITLE
Implement missing methods of `ProofSystemCompiler`

### DIFF
--- a/src/acvm_interop/proof_system.rs
+++ b/src/acvm_interop/proof_system.rs
@@ -35,7 +35,7 @@ impl ProofSystemCompiler for Gnark {
     ) -> Vec<u8> {
         // TODO: modify gnark serializer to accept the BTreeMap
         let values: Vec<FieldElement> = witness_values.values().copied().collect();
-        gnark_backend::prove(circuit, values).unwrap()
+        gnark_backend::prove_with_meta(circuit, values).unwrap()
     }
 
     fn verify_from_cs(
@@ -44,7 +44,7 @@ impl ProofSystemCompiler for Gnark {
         public_inputs: Vec<FieldElement>,
         circuit: Circuit,
     ) -> bool {
-        gnark_backend::verify(circuit, proof, &public_inputs).unwrap()
+        gnark_backend::verify_with_meta(circuit, proof, &public_inputs).unwrap()
     }
 
     fn get_exact_circuit_size(&self, circuit: &Circuit) -> u32 {
@@ -52,7 +52,7 @@ impl ProofSystemCompiler for Gnark {
     }
 
     fn preprocess(&self, circuit: &Circuit) -> (Vec<u8>, Vec<u8>) {
-        todo!()
+        gnark_backend::preprocess(circuit)
     }
 
     fn prove_with_pk(
@@ -61,7 +61,9 @@ impl ProofSystemCompiler for Gnark {
         witness_values: std::collections::BTreeMap<Witness, FieldElement>,
         proving_key: &[u8],
     ) -> Vec<u8> {
-        todo!()
+        // TODO: modify gnark serializer to accept the BTreeMap
+        let values: Vec<FieldElement> = witness_values.values().copied().collect();
+        gnark_backend::prove_with_pk(circuit, values, proving_key).unwrap()
     }
 
     fn verify_with_vk(
@@ -71,6 +73,6 @@ impl ProofSystemCompiler for Gnark {
         circuit: &Circuit,
         verification_key: &[u8],
     ) -> bool {
-        todo!()
+        gnark_backend::verify_with_vk(circuit, proof, &public_inputs, verification_key).unwrap()
     }
 }

--- a/src/gnark_backend_glue/mod.rs
+++ b/src/gnark_backend_glue/mod.rs
@@ -67,11 +67,19 @@ pub fn prove_with_meta(circuit: Circuit, values: Vec<FieldElement>) -> Result<Ve
     Ok(bytes.to_vec())
 }
 
-pub fn prove_with_pk(circuit: &Circuit, values: Vec<FieldElement>, proving_key: &[u8]) -> Result<Vec<u8>> {
+pub fn prove_with_pk(
+    circuit: &Circuit,
+    values: Vec<FieldElement>,
+    proving_key: &[u8],
+) -> Result<Vec<u8>> {
     todo!()
 }
 
-pub fn verify_with_meta(circuit: Circuit, proof: &[u8], public_inputs: &[FieldElement]) -> Result<bool> {
+pub fn verify_with_meta(
+    circuit: Circuit,
+    proof: &[u8],
+    public_inputs: &[FieldElement],
+) -> Result<bool> {
     let rawr1cs = RawR1CS::new(circuit, public_inputs.to_vec())?;
 
     // Serialize to json and then convert to GoString
@@ -91,7 +99,12 @@ pub fn verify_with_meta(circuit: Circuit, proof: &[u8], public_inputs: &[FieldEl
     }
 }
 
-pub fn verify_with_vk(circuit: &Circuit, proof: &[u8], public_inputs: &[FieldElement], verifying_key: &[u8]) -> Result<bool> {
+pub fn verify_with_vk(
+    circuit: &Circuit,
+    proof: &[u8],
+    public_inputs: &[FieldElement],
+    verifying_key: &[u8],
+) -> Result<bool> {
     todo!()
 }
 

--- a/src/gnark_backend_glue/mod.rs
+++ b/src/gnark_backend_glue/mod.rs
@@ -28,10 +28,22 @@ cfg_if::cfg_if! {
     }
 }
 
-pub fn prove(_circuit: Circuit, _values: Vec<FieldElement>) -> Result<Vec<u8>> {
+pub fn prove_with_meta(circuit: Circuit, values: Vec<FieldElement>) -> Result<Vec<u8>> {
     todo!()
 }
 
-pub fn verify(_circuit: Circuit, _proof: &[u8], _public_inputs: &[FieldElement]) -> Result<bool> {
+pub fn prove_with_pk(circuit: &Circuit, values: Vec<FieldElement>, proving_key: &[u8]) -> Result<Vec<u8>> {
+    todo!()
+}
+
+pub fn verify_with_meta(circuit: Circuit, proof: &[u8], public_inputs: &[FieldElement]) -> Result<bool> {
+    todo!()
+}
+
+pub fn verify_with_vk(circuit: &Circuit, proof: &[u8], public_inputs: &[FieldElement], verifying_key: &[u8]) -> Result<bool> {
+    todo!()
+}
+
+pub fn preprocess(circuit: &Circuit) -> (Vec<u8>, Vec<u8>) {
     todo!()
 }


### PR DESCRIPTION
These are passthrough methods that call the `gnark_backend` module which is the wrapper for the Go's backend.