### PR TITLE
Deserialization for felts

### DIFF
--- a/src/gnark_backend_wrapper/groth16/acir_to_r1cs.rs
+++ b/src/gnark_backend_wrapper/groth16/acir_to_r1cs.rs
@@ -1,6 +1,8 @@
 use super::{from_felt, Fr};
 use crate::acvm;
-use crate::gnark_backend_wrapper::groth16::serialize::{serialize_felt, serialize_felts};
+use crate::gnark_backend_wrapper::groth16::serialize::{
+    deserialize_felt, deserialize_felts, serialize_felt, serialize_felts,
+};
 use crate::gnark_backend_wrapper::groth16::GnarkBackendError;
 use std::num::TryFromIntError;
 
@@ -11,33 +13,50 @@ use std::num::TryFromIntError;
 // - These structures only support arithmetic gates, while the compiler has other
 // gate types. These can be added later once the backend knows how to deal with things like XOR
 // or once ACIR is taught how to do convert these black box functions to Arithmetic gates.
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct RawR1CS {
     pub gates: Vec<RawGate>,
     pub public_inputs: Vec<acvm::Witness>,
-    #[serde(serialize_with = "serialize_felts")]
+    #[serde(
+        serialize_with = "serialize_felts",
+        deserialize_with = "deserialize_felts"
+    )]
     pub values: Vec<Fr>,
     pub num_variables: u64,
     pub num_constraints: u64,
 }
 
-#[derive(Clone, serde::Serialize)]
+/*
+1. Implementar Deserialize para
+*/
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct RawGate {
     pub mul_terms: Vec<MulTerm>,
     pub add_terms: Vec<AddTerm>,
-    #[serde(serialize_with = "serialize_felt")]
+    #[serde(
+        serialize_with = "serialize_felt",
+        deserialize_with = "deserialize_felt"
+    )]
     pub constant_term: Fr,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct MulTerm {
+    #[serde(
+        serialize_with = "serialize_felt",
+        deserialize_with = "deserialize_felt"
+    )]
     pub coefficient: Fr,
     pub multiplicand: acvm::Witness,
     pub multiplier: acvm::Witness,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AddTerm {
+    #[serde(
+        serialize_with = "serialize_felt",
+        deserialize_with = "deserialize_felt"
+    )]
     pub coefficient: Fr,
     pub sum: acvm::Witness,
 }

--- a/src/gnark_backend_wrapper/groth16/serialize.rs
+++ b/src/gnark_backend_wrapper/groth16/serialize.rs
@@ -1,50 +1,8 @@
-use super::acir_to_r1cs::{AddTerm, MulTerm};
 use crate::gnark_backend_wrapper as gnark_backend;
-use ark_serialize::CanonicalSerialize;
-use serde::{ser::SerializeStruct, Serialize};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use serde::Deserialize;
 
-impl Serialize for MulTerm {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut serialized_coefficient = Vec::new();
-        self.coefficient
-            .serialize_uncompressed(&mut serialized_coefficient)
-            .map_err(serde::ser::Error::custom)?;
-        // Turn little-endian to big-endian.
-        serialized_coefficient.reverse();
-        let encoded_coefficient = hex::encode(serialized_coefficient);
-
-        let mut s = serializer.serialize_struct("MulTerm", 3)?;
-        s.serialize_field("coefficient", &encoded_coefficient)?;
-        s.serialize_field("multiplicand", &self.multiplicand)?;
-        s.serialize_field("multiplier", &self.multiplier)?;
-        s.end()
-    }
-}
-
-impl Serialize for AddTerm {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut serialized_coefficient = Vec::new();
-        self.coefficient
-            .serialize_uncompressed(&mut serialized_coefficient)
-            .map_err(serde::ser::Error::custom)?;
-        // Turn little-endian to big-endian.
-        serialized_coefficient.reverse();
-        let encoded_coefficient = hex::encode(serialized_coefficient);
-
-        let mut s = serializer.serialize_struct("AddTerm", 2)?;
-        s.serialize_field("coefficient", &encoded_coefficient)?;
-        s.serialize_field("sum", &self.sum)?;
-        s.end()
-    }
-}
-
-pub fn serialize_felt_unchecked(felt: &gnark_backend::groth16::Fr) -> Vec<u8> {
+pub fn serialize_felt_unchecked(felt: &gnark_backend::Fr) -> Vec<u8> {
     let mut serialized_felt = Vec::new();
     #[allow(clippy::unwrap_used)]
     felt.serialize_uncompressed(&mut serialized_felt).unwrap();
@@ -53,10 +11,7 @@ pub fn serialize_felt_unchecked(felt: &gnark_backend::groth16::Fr) -> Vec<u8> {
     serialized_felt
 }
 
-pub fn serialize_felt<S>(
-    felt: &gnark_backend::groth16::Fr,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
+pub fn serialize_felt<S>(felt: &gnark_backend::Fr, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::ser::Serializer,
 {
@@ -69,10 +24,7 @@ where
     serializer.serialize_str(&encoded_coefficient)
 }
 
-pub fn serialize_felts<S>(
-    felts: &[gnark_backend::groth16::Fr],
-    serializer: S,
-) -> Result<S::Ok, S::Error>
+pub fn serialize_felts<S>(felts: &[gnark_backend::Fr], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::ser::Serializer,
 {
@@ -87,4 +39,53 @@ where
     );
     let encoded_buff = hex::encode(buff);
     serializer.serialize_str(&encoded_buff)
+}
+
+pub fn deserialize_felt<'de, D>(deserializer: D) -> Result<gnark_backend::Fr, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let felt_bytes = String::deserialize(deserializer)?;
+    let mut decoded = hex::decode(felt_bytes).map_err(serde::de::Error::custom)?;
+    // Turn big-endian to little-endian.
+    decoded.reverse();
+    gnark_backend::Fr::deserialize_uncompressed(decoded.as_slice())
+        .map_err(serde::de::Error::custom)
+}
+
+pub fn deserialize_felts<'de, D>(deserializer: D) -> Result<Vec<gnark_backend::Fr>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let serialized_felts = String::deserialize(deserializer)?;
+
+    let mut decoded_felts = hex::decode(serialized_felts).map_err(serde::de::Error::custom)?;
+
+    let n_felts: usize = u32::from_be_bytes(
+        decoded_felts
+            .get(..4)
+            .ok_or_else(|| serde::de::Error::custom("Error getting felts size"))?
+            .try_into()
+            .map_err(serde::de::Error::custom)?,
+    )
+    .try_into()
+    .map_err(serde::de::Error::custom)?;
+    let mut deserialized_felts: Vec<gnark_backend::Fr> = Vec::with_capacity(n_felts);
+
+    decoded_felts
+        .get_mut(4..) // Skip the vector length corresponding to the first four bytes.
+        .ok_or_else(|| serde::de::Error::custom("Error getting decoded felts"))?
+        .chunks_mut(32)
+        .try_for_each(|decoded_felt| {
+            // Turn big-endian to little-endian.
+            decoded_felt.reverse();
+            // Here I reference after dereference because I had a mutable reference and I need a non-mutable one.
+            let felt: gnark_backend::Fr =
+                CanonicalDeserialize::deserialize_uncompressed(&*decoded_felt)
+                    .map_err(serde::de::Error::custom)?;
+            deserialized_felts.push(felt);
+            Ok::<(), D::Error>(())
+        })?;
+
+    Ok(deserialized_felts)
 }


### PR DESCRIPTION
## Changes
- Implement deserialize method for felt.
- Implement deseriliaze method for felts.
- Remove `MulTerm` & `AddTerm` `Serialize` implementations and replace them with derives.
- Also derive `Deserialize` for all the structs.