### PR TITLE
Fix `np_language`

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -30,7 +30,7 @@ fn get_values_from_witness_tree(
 
 impl ProofSystemCompiler for Gnark {
     fn np_language(&self) -> Language {
-        Language::R1CS
+        Language::PLONKCSat { width: 3 }
     }
 
     fn black_box_function_supported(&self, opcode: &BlackBoxFunc) -> bool {


### PR DESCRIPTION
This error was causing the ACIR to generate the wrong opcodes (invalid for Plonk).