### PR TITLE
Fix bug in constraint generation

### DIFF
--- a/gnark_backend_ffi/backend/plonk/sparse_r1cs.go
+++ b/gnark_backend_ffi/backend/plonk/sparse_r1cs.go
@@ -18,12 +18,13 @@ func handleOpcodes(a acir.ACIR, sparseR1CS constraint.SparseR1CS, indexMap map[s
 		switch opcode := opcode.Data.(type) {
 		case *acir_opcode.ArithmeticOpcode:
 			var xa, xb, xc int
-			var qL, qR, qO, qC, qM constraint.Coeff
+			var qL, qR, qO, qC, qM1, qM2 constraint.Coeff
 
 			// Case qM⋅(xa⋅xb)
 			if len(opcode.MulTerms) != 0 {
 				mulTerm := opcode.MulTerms[0]
-				qM = sparseR1CS.FromInterface(mulTerm.Coefficient)
+				qM1 = sparseR1CS.FromInterface(mulTerm.Coefficient)
+				qM2 = sparseR1CS.FromInterface(1)
 				xa = indexMap[fmt.Sprint(int(mulTerm.MultiplicandIndex))]
 				xb = indexMap[fmt.Sprint(int(mulTerm.MultiplierIndex))]
 			}
@@ -73,7 +74,7 @@ func handleOpcodes(a acir.ACIR, sparseR1CS constraint.SparseR1CS, indexMap map[s
 				L: sparseR1CS.MakeTerm(&qL, xa),
 				R: sparseR1CS.MakeTerm(&qR, xb),
 				O: sparseR1CS.MakeTerm(&qO, xc),
-				M: [2]constraint.Term{sparseR1CS.MakeTerm(&qM, xa), sparseR1CS.MakeTerm(&qM, xb)},
+				M: [2]constraint.Term{sparseR1CS.MakeTerm(&qM1, xa), sparseR1CS.MakeTerm(&qM2, xb)},
 				K: K.CoeffID(),
 			}
 


### PR DESCRIPTION
The way the API is designed requires the multiplication term in a Plonk constraint to have a coefficient per $x_i$ (for $x_a$ and $x_b$ in this case) and we were using the same for both of them and that caused to have $qM$ squared instead of just $qM$, so I fixed one of them to be always 1.

We were doing $q_{M}^{2} \cdot (x_{a} \cdot x_{b})$, now we are doing $q_{M} \cdot (x_{a} \cdot x_{b})$ correctly because of the fixed 1 coefficient.